### PR TITLE
fix(seed:db): create provinces after admins and enforce required admin field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ web_modules/
 
 # Admin credentials (contains passwords)
 server/admins.json
+server/seed-config.json
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
 		"dev": "nodemon --exec ts-node src/index.ts",
 		"build": "tsc",
 		"start": "node dist/index.js",
-		"seed:admins": "ts-node src/scripts/seed-admins.ts"
+		"seed:db": "ts-node src/scripts/seed-db.ts"
 	},
 	"keywords": [],
 	"author": "",

--- a/server/seed-config.json
+++ b/server/seed-config.json
@@ -1,0 +1,20 @@
+{
+	"admins": {
+		"globalAdmin": {
+			"username": "gadmin",
+			"password": "123456"
+		},
+		"provinceAdmins": [
+			{
+				"username": "tehran_admin",
+				"password": "123456",
+				"provinceName": "Tehran"
+			},
+			{
+				"username": "alborz_admin",
+				"password": "123456",
+				"provinceName": "Alborz"
+			}
+		]
+	}
+}

--- a/server/src/scripts/seed-db.ts
+++ b/server/src/scripts/seed-db.ts
@@ -8,305 +8,173 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 interface AdminConfig {
-	globalAdmin?: {
-		username: string;
-		password: string;
-	};
-	provinceAdmins?: Array<{
-		username: string;
-		password: string;
-		provinceName?: string;
-	}>;
+    globalAdmin?: {
+        username: string;
+        password: string;
+    };
+    provinceAdmins?: Array<{
+        username: string;
+        password: string;
+        provinceName: string;
+    }>;
 }
 
 interface SeedConfig {
-	admins: AdminConfig;
+    admins: AdminConfig;
 }
 
-
-// Helper functions from seed-admins.ts
 function isValidString(value: string | undefined | null): boolean {
-	return value !== undefined && value !== null && value.trim() !== '';
-}
-
-interface AdminCredentials {
-	username: string;
-	password: string;
-}
-
-interface SeedStats {
-	globalAdminCreated: boolean;
-	globalAdminUpdated: boolean;
-	provinceAdminsCreated: number;
-	provinceAdminsUpdated: number;
-	provinceAdminsLinked: number;
-	errors: string[];
-}
-
-function validateCredentials(credentials: AdminCredentials, context: string): string | null {
-	if (!isValidString(credentials.username)) {
-		return `${context}: username is required`;
-	}
-	if (!isValidString(credentials.password)) {
-		return `${context}: password is required`;
-	}
-	return null;
+    return value !== undefined && value !== null && value.trim() !== '';
 }
 
 async function hashPassword(password: string): Promise<string> {
-	return bcrypt.hash(password, 10);
+    return bcrypt.hash(password, 10);
 }
 
-async function createGlobalAdmin(credentials: AdminCredentials, stats: SeedStats): Promise<void> {
-	const validationError = validateCredentials(credentials, 'Global admin');
-	if (validationError) {
-		const errMsg = `${validationError}, skipping...`;
-		console.error(`  ❌ ${errMsg}`);
-		stats.errors.push(errMsg);
-		return;
-	}
-
-	const { username, password } = credentials;
-
-	try {
-		const existingUser = await User.findOne({ username });
-		if (existingUser) {
-			const samePassword = await bcrypt.compare(password, existingUser.passwordHash);
-			if (!samePassword) {
-				existingUser.passwordHash = await hashPassword(password);
-				await existingUser.save();
-				logger.info("Global admin password updated", { username });
-				console.log(`  ✅ Updated password for global admin: ${username} from config`);
-				stats.globalAdminUpdated = true;
-			} else {
-				logger.debug("Global admin password unchanged", { username });
-				console.log(`  ℹ️  Password for global admin "${username}" already matches config`);
-			}
-			return;
-		}
-
-		const passwordHash = await hashPassword(password);
-		const user = new User({
-			username,
-			passwordHash,
-			role: USER_ROLE.GLOBAL_ADMIN,
-		});
-
-		await user.save();
-		logger.info("Global admin created", { username });
-		console.log(`  ✅ Created global admin: ${username}`);
-		stats.globalAdminCreated = true;
-	} catch (err) {
-		const errMsg = `Failed to create global admin ${username}`;
-		logger.error(errMsg, err);
-		console.error(`  ❌ ${errMsg}`);
-		stats.errors.push(errMsg);
-	}
+async function validateCredentials(username: string, password: string, context: string) {
+    if (!isValidString(username)) throw new Error(`${context}: username is required`);
+    if (!isValidString(password)) throw new Error(`${context}: password is required`);
 }
 
-async function linkProvinceToAdmin(user: InstanceType<typeof User>, provinceName: string, stats: SeedStats): Promise<boolean> {
-	try {
-		const province = await Province.findOne({ name: provinceName });
-		if (!province) {
-			const errMsg = `Province "${provinceName}" not found`;
-			logger.warn(errMsg, { username: user.username });
-			return false;
-		}
+// ------------------------------------------------------------
+// GLOBAL ADMIN
+// ------------------------------------------------------------
+async function createOrUpdateGlobalAdmin(credentials: { username: string; password: string }) {
+    const { username, password } = credentials;
+    await validateCredentials(username, password, 'Global admin');
 
-		if (province.admin) {
-			const existingAdmin = await User.findById(province.admin);
-			if (existingAdmin) {
-				logger.warn("Province admin will be replaced", {
-					province: provinceName,
-					oldAdmin: existingAdmin.username,
-					newAdmin: user.username
-				});
-				console.log(`  ⚠️  Province "${provinceName}" already has admin "${existingAdmin.username}", will be replaced`);
-			}
-		}
+    const existing = await User.findOne({ username });
 
-		user.provinceId = province._id;
-		await user.save();
+    if (existing) {
+        const same = await bcrypt.compare(password, existing.passwordHash);
+        if (!same) {
+            existing.passwordHash = await hashPassword(password);
+            await existing.save();
+            console.log(`  🔄 Updated global admin password: ${username}`);
+        } else {
+            console.log(`  ℹ️ Global admin password unchanged: ${username}`);
+        }
+        return existing;
+    }
 
-		province.admin = user._id;
-		await province.save();
+    const user = new User({
+        username,
+        passwordHash: await hashPassword(password),
+        role: USER_ROLE.GLOBAL_ADMIN
+    });
 
-		logger.info("Province admin linked", { username: user.username, province: provinceName });
-		return true;
-	} catch (err) {
-		logger.error("Failed to link province admin", err);
-		stats.errors.push(`Failed to link ${user.username} to province ${provinceName}`);
-		return false;
-	}
+    await user.save();
+    console.log(`  ✅ Created global admin: ${username}`);
+    return user;
 }
 
-async function createProvinceAdmin(credentials: AdminCredentials & { provinceName?: string }, stats: SeedStats): Promise<void> {
-	const validationError = validateCredentials(credentials, `Province admin "${credentials.username}"`);
-	if (validationError) {
-		const errMsg = `${validationError}, skipping...`;
-		console.error(`  ❌ ${errMsg}`);
-		stats.errors.push(errMsg);
-		return;
-	}
+// ------------------------------------------------------------
+// PROVINCE ADMINS (users only, no province creation yet)
+// ------------------------------------------------------------
+async function createOrUpdateProvinceAdmin(
+    username: string,
+    password: string
+) {
+    await validateCredentials(username, password, `Province admin "${username}"`);
 
-	const { username, password, provinceName } = credentials;
+    let user = await User.findOne({ username });
 
-	try {
-		const existingUser = await User.findOne({ username });
-		let user: InstanceType<typeof User>;
+    if (user) {
+        const same = await bcrypt.compare(password, user.passwordHash);
+        if (!same) {
+            user.passwordHash = await hashPassword(password);
+            console.log(`  🔄 Updated password for province admin: ${username}`);
+        }
+        user.role = USER_ROLE.PROVINCE_ADMIN;
+        await user.save();
+        return user;
+    }
 
-		if (existingUser) {
-			if (existingUser.role !== USER_ROLE.PROVINCE_ADMIN) {
-				existingUser.role = USER_ROLE.PROVINCE_ADMIN;
-			}
+    user = new User({
+        username,
+        passwordHash: await hashPassword(password),
+        role: USER_ROLE.PROVINCE_ADMIN
+    });
 
-			const samePassword = await bcrypt.compare(password, existingUser.passwordHash);
-			if (!samePassword) {
-				existingUser.passwordHash = await hashPassword(password);
-				await existingUser.save();
-				logger.info("Province admin password updated", { username });
-				console.log(`  ✅ Updated password for province admin: ${username} from config`);
-				stats.provinceAdminsUpdated++;
-			} else {
-				logger.debug("Province admin password unchanged", { username });
-				console.log(`  ℹ️  Password for province admin "${username}" already matches config`);
-			}
-
-			user = existingUser;
-		} else {
-			const passwordHash = await hashPassword(password);
-			user = new User({
-				username,
-				passwordHash,
-				role: USER_ROLE.PROVINCE_ADMIN,
-			});
-			await user.save();
-			logger.info("Province admin user created", { username });
-			console.log(`  ✅ Created province admin user: ${username}`);
-			stats.provinceAdminsCreated++;
-		}
-
-		if (isValidString(provinceName)) {
-			const linked = await linkProvinceToAdmin(user, provinceName!, stats);
-			if (linked) {
-				logger.info("Province admin created and linked", { username, province: provinceName });
-				console.log(`  ✅ Created province admin: ${username} (linked to ${provinceName})`);
-				stats.provinceAdminsLinked++;
-			} else {
-				logger.warn("Province admin created but not linked", { username, province: provinceName });
-				console.log(`  ⚠️  Created province admin: ${username} (province "${provinceName}" not found, not linked)`);
-			}
-		} else {
-			logger.warn("Province admin created without province", { username });
-			console.log(`  ⚠️  Created province admin: ${username} (no province name provided)`);
-		}
-	} catch (err) {
-		const errMsg = `Failed to create province admin ${username}`;
-		logger.error(errMsg, err);
-		console.error(`  ❌ ${errMsg}`);
-		stats.errors.push(errMsg);
-	}
+    await user.save();
+    console.log(`  ✅ Created province admin user: ${username}`);
+    return user;
 }
 
-// Seed provinces by extracting unique province names from provinceAdmins
-async function seedProvincesFromAdmins(provinceAdmins: { provinceName?: string }[]) {
-	const uniqueProvinces = Array.from(new Set(
-		provinceAdmins
-			.map(a => a.provinceName)
-			.filter((name): name is string => !!name)
-	));
-	for (const name of uniqueProvinces) {
-		let existing = await Province.findOne({ name });
-		if (!existing) {
-			existing = new Province({ name });
-			await existing.save();
-			logger.info('Province created', { name });
-			console.log(`  ✅ Created province: ${name}`);
-		} else {
-			console.log(`  ℹ️  Province already exists: ${name}`);
-		}
-	}
+// ------------------------------------------------------------
+// CREATE PROVINCES *AFTER* ADMINS EXIST
+// ------------------------------------------------------------
+async function createProvincesWithAdmins(provinceAdmins: Array<{ username: string; provinceName: string }>) {
+    for (const entry of provinceAdmins) {
+        const { username, provinceName } = entry;
+
+        const admin = await User.findOne({ username });
+        if (!admin) {
+            console.log(`  ❌ Cannot create province "${provinceName}" — admin "${username}" not found`);
+            continue;
+        }
+
+        let province = await Province.findOne({ name: provinceName });
+
+        if (province) {
+            // Update admin if needed
+            if (!province.admin || province.admin.toString() !== admin._id.toString()) {
+                province.admin = admin._id;
+                await province.save();
+                console.log(`  🔄 Updated province "${provinceName}" admin → ${username}`);
+            } else {
+                console.log(`  ℹ️ Province "${provinceName}" already linked to ${username}`);
+            }
+        } else {
+            // Create province WITH admin (required)
+            province = new Province({
+                name: provinceName,
+                admin: admin._id
+            });
+            await province.save();
+            console.log(`  ✅ Created province "${provinceName}" with admin ${username}`);
+        }
+
+        // Update admin → province link
+        admin.provinceId = province._id;
+        await admin.save();
+    }
 }
 
-// ...existing admin seeding logic, but call seedProvinces before seeding admins
-
-
+// ------------------------------------------------------------
+// MAIN SEEDING FLOW
+// ------------------------------------------------------------
 async function seedDB() {
-	const configPath = path.join(__dirname, '../../seed-config.json');
-	if (!fs.existsSync(configPath)) {
-		console.error(`Error: seed-config.json not found at ${configPath}`);
-		process.exit(1);
-	}
-	const configContent = fs.readFileSync(configPath, 'utf-8');
-	const config: SeedConfig = JSON.parse(configContent);
+    const configPath = path.join(__dirname, '../../seed-config.json');
+    if (!fs.existsSync(configPath)) {
+        console.error(`Error: seed-config.json not found at ${configPath}`);
+        process.exit(1);
+    }
 
-	await connectDB();
-	logger.info('Database connected');
-	console.log('✅ Connected to database\n');
+    const config: SeedConfig = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
 
-	// Seed provinces based on provinceAdmins
-	if (config.admins && config.admins.provinceAdmins && config.admins.provinceAdmins.length > 0) {
-		console.log('Seeding provinces from provinceAdmins...');
-		await seedProvincesFromAdmins(config.admins.provinceAdmins);
-	}
+    await connectDB();
+    console.log('✅ Connected to database\n');
 
-	// Seed admins
-	const stats: SeedStats = {
-		globalAdminCreated: false,
-		globalAdminUpdated: false,
-		provinceAdminsCreated: 0,
-		provinceAdminsUpdated: 0,
-		provinceAdminsLinked: 0,
-		errors: []
-	};
+    // 1. Global admin
+    if (config.admins.globalAdmin) {
+        console.log('Creating global admin...');
+        await createOrUpdateGlobalAdmin(config.admins.globalAdmin);
+    }
 
-	// Create global admin
-	console.log('Creating global admin...');
-	if (config.admins && config.admins.globalAdmin) {
-		await createGlobalAdmin(config.admins.globalAdmin, stats);
-	} else {
-		console.log('  ⚠️  No global admin configured, skipping...');
-	}
+    // 2. Province admins (users only)
+    console.log('\nCreating province admin users...');
+    const provinceAdmins = config.admins.provinceAdmins || [];
+    for (const admin of provinceAdmins) {
+        await createOrUpdateProvinceAdmin(admin.username, admin.password);
+    }
 
-	// Create province admins
-	console.log('\nCreating province admins...');
-	if (!config.admins || !config.admins.provinceAdmins || config.admins.provinceAdmins.length === 0) {
-		console.log('  ⚠️  No province admins configured, skipping...');
-	} else {
-		for (const admin of config.admins.provinceAdmins) {
-			await createProvinceAdmin(admin, stats);
-		}
-	}
+    // 3. Provinces WITH admins assigned
+    console.log('\nCreating provinces with assigned admins...');
+    await createProvincesWithAdmins(provinceAdmins);
 
-	// Print summary
-	console.log('\n' + '='.repeat(50));
-	console.log('SEED SUMMARY');
-	console.log('='.repeat(50));
-
-	if (stats.globalAdminCreated) {
-		console.log('✅ Global Admin: Created');
-	} else if (stats.globalAdminUpdated) {
-		console.log('✅ Global Admin: Updated');
-	} else {
-		console.log('ℹ️  Global Admin: No changes');
-	}
-
-	console.log(`Province Admins:`);
-	console.log(`  Created: ${stats.provinceAdminsCreated}`);
-	console.log(`  Updated: ${stats.provinceAdminsUpdated}`);
-	console.log(`  Linked:  ${stats.provinceAdminsLinked}`);
-
-	if (stats.errors.length > 0) {
-		console.log(`\nErrors (${stats.errors.length}):`);
-		stats.errors.forEach(err => console.log(`  • ${err}`));
-		logger.warn("Seed completed with errors", { errorCount: stats.errors.length });
-		console.log('\n⚠️  Seeding completed with errors');
-		process.exit(1);
-	} else {
-		logger.info("Seeding completed successfully");
-		console.log('\n✅ Seeding completed successfully!');
-		process.exit(0);
-	}
+    console.log('\n✅ Seeding completed successfully!');
+    process.exit(0);
 }
 
 seedDB();


### PR DESCRIPTION
- Reordered seeding pipeline: province admins are created before provinces
- Provinces are now created with their assigned admin to satisfy schema requirements
- Added bidirectional linking (admin.provinceId ↔ province.admin)
- Removed early province creation step that violated validation rules
- Improved idempotency and consistency across seeding operations
- Renamed seed-admin to seed-db and added broader config coverage